### PR TITLE
Annotate terminating nodes

### DIFF
--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -35,6 +35,7 @@ var log = logrus.New()
 
 const (
 	ageUnreapableAnnotationKey = "governor.keikoproj.io/age-unreapable"
+	terminatingAnnotationKey   = "governor.keikoproj.io/terminating"
 )
 
 // Validate command line arguments
@@ -489,6 +490,7 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 
 		if !ctx.DryRun {
 			log.Infof("reaping old node %v -> %v", instance.NodeName, instance.InstanceID)
+			ctx.annotateNode(instance.NodeName, terminatingAnnotationKey, "true")
 			err = terminateInstance(w.ASG, instance.InstanceID)
 			if err != nil {
 				return err
@@ -544,6 +546,7 @@ func (ctx *ReaperContext) reapUnhealthyNodes(w ReaperAwsAuth) error {
 
 		if !ctx.DryRun {
 			log.Infof("reaping unhealthy node %v -> %v", node, instance)
+			ctx.annotateNode(node, terminatingAnnotationKey, "true")
 			err = terminateInstance(w.ASG, instance)
 			if err != nil {
 				return err

--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -496,7 +496,7 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 			}
 
 			if err := ctx.annotateNode(instance.NodeName, terminatingAnnotationKey, "true"); err != nil {
-				log.Warn("failed to add terminating annotation on node '%v'")
+				log.Warnf("failed to add terminating annotation on node '%v'", instance.NodeName)
 			}
 
 			// Throttle deletion
@@ -557,7 +557,7 @@ func (ctx *ReaperContext) reapUnhealthyNodes(w ReaperAwsAuth) error {
 			}
 
 			if err := ctx.annotateNode(node, terminatingAnnotationKey, "true"); err != nil {
-				log.Warn("failed to add terminating annotation on node '%v'")
+				log.Warnf("failed to add terminating annotation on node '%v'", node)
 			}
 
 			// Throttle deletion


### PR DESCRIPTION
Fixes #24 

This adds an annotate with key `governor.keikoproj.io/terminating: "true"` prior to issuing a terminate.