### PR TITLE
State annotations

### DIFF
--- a/pkg/reaper/nodereaper/nodereaper_test.go
+++ b/pkg/reaper/nodereaper/nodereaper_test.go
@@ -527,8 +527,6 @@ type stubASG struct {
 	DesiredCapacity    int64
 }
 
-// TEST CASES
-
 func TestGetUnreadyNodesPositive(t *testing.T) {
 	reaper := newFakeReaperContext()
 	testCase := ReaperUnitTest{


### PR DESCRIPTION
Improved the implementation in #24 

Node will be annotated with `governor.keikoproj.io/state: draining` before drain is executed.
Node will be annotated with `governor.keikoproj.io/state: termination-issued` after termination API is called.