### PR TITLE
Nodereaper skip label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _output/*
 bin
 bin/*
 .DS_Store
+.idea

--- a/pkg/reaper/nodereaper/nodereaper_test.go
+++ b/pkg/reaper/nodereaper/nodereaper_test.go
@@ -228,14 +228,6 @@ func loadFakeAPI(ctx *ReaperContext) {
 
 func createNodeLabels(nodes []FakeNode, ctx *ReaperContext, skipLabels []SkipLabel) []map[string]string {
 	var ret []map[string]string
-	//numSkipLabel := 0
-	//if len(numSkipLabel_opt) > 0 {
-	//	numSkipLabel = numSkipLabel_opt[0]
-	//}
-	//if numSkipLabel > len(nodes) {
-	//	fmt.Println("Requested number of nodes to be skipped is greater than the given list of nodes. Defaulting to list of nodes size.")
-	//	numSkipLabel = len(nodes)
-	//}
 	for i, n := range nodes {
 		nodeLabels := make(map[string]string)
 		if n.isMaster {
@@ -258,11 +250,6 @@ func createFakeNodes(nodes []FakeNode, ctx *ReaperContext, skipLabels []SkipLabe
 	nodeLabelsList := createNodeLabels(nodes, ctx, skipLabels)
 	for i, n := range nodes {
 		nodeLabels := nodeLabelsList[i]
-		//if n.isMaster {
-		//	nodeLabels["kubernetes.io/role"] = "master"
-		//} else {
-		//	nodeLabels["kubernetes.io/role"] = "node"
-		//}
 
 		creationTimestamp := metav1.Time{Time: time.Now()}
 		if n.ageMinutes != 0 {


### PR DESCRIPTION
Added 5 node label flag checks that can be used to skip reaping for a specific node with the given label:

```
"governor.keikoproj.io/node-reaper-disabled" 
"governor.keikoproj.io/reap-unready-disabled"
"governor.keikoproj.io/reap-unknown-disabled"
"governor.keikoproj.io/reap-flappy-disabled"
"governor.keikoproj.io/reap-old-disabled"
```

Each label correspond to a specific criteria for reaping, except for `governor.keikoproj.io/node-reaper-disabled` which ignore reaping regardless of the criteria. 