### PR TITLE
reap evicted pods

### DIFF
--- a/pkg/reaper/podreaper/podreaper.go
+++ b/pkg/reaper/podreaper/podreaper.go
@@ -293,7 +293,10 @@ func (ctx *ReaperContext) deriveFailedPods() {
 			}
 		}
 
+		// include pods which have no containerstatuses, such as evicted pods
 		if len(times) == 0 {
+			log.Infof("%v/%v is reapable !! pod in failed state for unknown diff: ??/%v", podNamespace, podName, ctx.ReapFailedAfter)
+			ctx.FailedPods[podName] = podNamespace
 			continue
 		}
 

--- a/pkg/reaper/podreaper/podreaper_test.go
+++ b/pkg/reaper/podreaper/podreaper_test.go
@@ -352,6 +352,10 @@ func TestReapCompletedFailedDisable(t *testing.T) {
 					getContainerStatus("container-2", PodFailedReason, time.Now().Add(time.Duration(-80)*time.Minute)),
 				},
 			},
+			{
+				phase:      v1.PodFailed,
+				containers: []v1.ContainerStatus{},
+			},
 		},
 		FakeReaper:        reaper,
 		ExpectedCompleted: 0,
@@ -439,11 +443,15 @@ func TestReapFailedPositive(t *testing.T) {
 					getContainerStatus("container-2", PodFailedReason, time.Now().Add(time.Duration(-10)*time.Minute)),
 				},
 			},
+			{
+				phase:      v1.PodFailed,
+				containers: []v1.ContainerStatus{},
+			},
 		},
 		FakeReaper:       reaper,
-		ExpectedFailed:   1,
-		ExpectedReapable: 1,
-		ExpectedReaped:   1,
+		ExpectedFailed:   2,
+		ExpectedReapable: 2,
+		ExpectedReaped:   2,
 	}
 	testCase.Run(t, false)
 }


### PR DESCRIPTION
Fixes #33 

This fixes a bug where we don't properly reap evicted pods.
This change ignores `--reap-failed-after` flag, if there are no containerstatuses in the failed pod, and proceeds to mark it reapable essentially ignoring that flag.

