### PR TITLE
Reconsider unreapable nodes after specified time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 	rm -rf _output
 
 test:
-	go test -v ./... -coverprofile ./coverage.txt
+	CGO_ENABLED=0 go test -v ./... -coverprofile ./coverage.txt
 
 vtest:
 	go test -v ./... -coverprofile ./coverage.txt --logging-enabled

--- a/cmd/governor/app/nodereaper.go
+++ b/cmd/governor/app/nodereaper.go
@@ -63,4 +63,5 @@ func init() {
 	nodeReapCmd.Flags().StringVar(&nodeReaperArgs.ReapUnjoinedKey, "reap-unjoined-tag-key", "", "BE CAREFUL! EC2 tag key that identfies a joining node")
 	nodeReapCmd.Flags().StringVar(&nodeReaperArgs.ReapUnjoinedValue, "reap-unjoined-tag-value", "", "BE CAREFUL! EC2 tag value that identfies a joining node")
 	nodeReapCmd.Flags().StringArrayVar(&nodeReaperArgs.ReapTainted, "reap-tainted", []string{}, "marks nodes with a given taint reapable, must be in format of comma separated taints key=value:effect, key:effect or key")
+	nodeReapCmd.Flags().Float64Var(&nodeReaperArgs.ReconsiderUnreapableAfter, "reconsider-unreapable-after", 10, "Time (in minutes) after which reconsider unreapable nodes")
 }

--- a/pkg/reaper/nodereaper/helpers.go
+++ b/pkg/reaper/nodereaper/helpers.go
@@ -154,7 +154,7 @@ func (ctx *ReaperContext) drainNode(name string, dryRun bool) error {
 			ctx.publishEvent(ctx.SelfNamespace, event)
 			if err.Error() == "command execution timed out" {
 				log.Warnf("failed to drain node %v, drain command timed-out", name)
-				ctx.annotateNode(name, ageUnreapableAnnotationKey, "true")
+				ctx.annotateNode(name, ageUnreapableAnnotationKey, getUTCNowStr())
 				ctx.uncordonNode(name, dryRun)
 				return err
 			}
@@ -421,4 +421,8 @@ func getInstanceIDByPrivateDNS(instances []*ec2.Instance, dnsName string) string
 		}
 	}
 	return ""
+}
+
+func getUTCNowStr() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/pkg/reaper/nodereaper/types.go
+++ b/pkg/reaper/nodereaper/types.go
@@ -57,6 +57,7 @@ type Args struct {
 	AgeReapThrottle              int64
 	ReapAfter                    float64
 	ReapTainted                  []string
+	ReconsiderUnreapableAfter    float64
 }
 
 // ReaperContext holds the context of the node-reaper and target cluster
@@ -87,6 +88,7 @@ type ReaperContext struct {
 	MaxKill                      int
 	TimeToReap                   float64
 	ReapTainted                  []v1.Taint
+	ReconsiderUnreapableAfter    float64
 	// runtime
 	UnreadyNodes              []v1.Node
 	AllNodes                  []v1.Node


### PR DESCRIPTION
- Add flag `--reconsider-unreapable-node` with default value 10 mins
- When a node drain failed, set the current time to `governor.keikoproj.io/age-unreapable` annotation
- Backward compatibility with previous value for the annotation

Fixes: #39