### PR TITLE
Log node drain command output as info log

### DIFF
--- a/pkg/reaper/nodereaper/helpers.go
+++ b/pkg/reaper/nodereaper/helpers.go
@@ -146,7 +146,8 @@ func (ctx *ReaperContext) drainNode(name string, dryRun bool) error {
 		if err := ctx.annotateNode(name, stateAnnotationKey, drainingStateName); err != nil {
 			log.Warnf("failed to update state annotation on node '%v'", name)
 		}
-		_, err := runCommandWithContext(drainCommand, drainArgs, ctx.DrainTimeoutSeconds)
+		cmdOut, err := runCommandWithContext(drainCommand, drainArgs, ctx.DrainTimeoutSeconds)
+		log.Infof("drain command output: %s", cmdOut)
 		if err != nil {
 			event := ctx.getUnreapableDrainFailureEvent(name, err.Error())
 			ctx.publishEvent(ctx.SelfNamespace, event)


### PR DESCRIPTION
Sometimes need to look at the output of drain command to figure out which pod on a node is causing
drain command failure/timeout.

Signed-off-by: Vivek Singh <svivekkumar@vmware.com>