### PR TITLE
Refactor ReapableInstances to avoid ASG Validation selectively 

### DIFF
--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -416,7 +416,7 @@ func (ctx *ReaperContext) deriveGhostDrainReapableNodes(w ReaperAwsAuth) error {
 		for node, instance := range ctx.GhostInstances {
 			log.Infof("node %v is drain-reapable, referencing terminated instance %v !! State = Ghost", node, instance)
 			ctx.addDrainable(node, instance)
-			ctx.addReapable(node, instance, false)
+			ctx.addReapable(node, instance, ctx.AsgValidation)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>

Fixes #51 

This refactor ReapableInstances into a structured object instead of a map, which allows to select if a specific instance requires ASG validation.

With this change, even if ASG Validation is on, unjoined nodes will be terminated.