### PR TITLE
Pull region from node labels if well known label is present

### DIFF
--- a/pkg/reaper/nodereaper/helpers.go
+++ b/pkg/reaper/nodereaper/helpers.go
@@ -245,10 +245,17 @@ func getNodeAgeMinutes(n *v1.Node) int {
 }
 
 func getNodeRegion(n *v1.Node) string {
-	providerID := n.Spec.ProviderID
-	splitProviderID := strings.Split(providerID, "/")
-	regionFullName := splitProviderID[len(splitProviderID)-2]
-	regionName := regionFullName[:len(regionFullName)-1]
+	var regionName  = ""
+	labels := n.GetLabels()
+	if labels != nil {
+		regionName = labels["topology.kubernetes.io/region"]
+	}
+	if regionName == "" {
+		providerID := n.Spec.ProviderID
+		splitProviderID := strings.Split(providerID, "/")
+		regionFullName := splitProviderID[len(splitProviderID)-2]
+		regionName = regionFullName[:len(regionFullName)-1]
+	}
 	return regionName
 }
 

--- a/pkg/reaper/nodereaper/nodereaper_test.go
+++ b/pkg/reaper/nodereaper/nodereaper_test.go
@@ -1623,6 +1623,30 @@ func TestProviderIDParser(t *testing.T) {
 	}
 }
 
+func TestRegionDetection(t *testing.T) {
+	// TestDescription: Region value in annotation should take priority over providerId
+	reaper := newFakeReaperContext()
+	reaper.AsgValidation = false
+	reaper.DryRun = true
+
+	node := v1.Node{
+		Spec: v1.NodeSpec{
+			ProviderID: "aws:///us-west-2a/i-1234567890abcdef0",
+		},
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+			"topology.kubernetes.io/region": "us-east-2",
+		}},
+	}
+
+	providerRegion := getNodeRegion(&node)
+	expectedRegion := "us-east-2"
+
+	if providerRegion != expectedRegion {
+		t.Fatalf("expected Region: %v, got: %v", expectedRegion, providerRegion)
+	}
+}
+
+
 func TestSkipLabelReaper(t *testing.T) {
 	reaper := newFakeReaperContext()
 	reaper.ReapUnknown = true


### PR DESCRIPTION
Use region value from well known labels if present. 

The current region detection from node provider assumes that zones always follow a similar format to `us-west-2a`, but this is not the case. 

Our local zones, which have a zone id of `us-west-2-lax1a`, are currently getting parsed with 'us-west-2-lax1` as the region, which is incorrect. Switching to the cloud-provider managed field here should generally be higher fidelity. 
Signed-off-by: Jonah Back <jonah@jonahback.com>