### PR TITLE
Bump Go from EOL 1.25 to supported 1.26

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -12,13 +12,13 @@ jobs:
     name: unit-test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v6
-      with:
-        go-version: ^1.21
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
 
     - name: Test
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 ARG TARGETOS TARGETARCH
 
 WORKDIR /go/src/github.com/keikoproj/governor

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keikoproj/governor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bring governor onto currently supported Go 1.26. As of 2026-09-10, Go only supports 1.26 and 1.27; `go.mod` was on `1.25.0` and the Dockerfile still used `golang:1.24`.

## Changes
- `go.mod` `go` directive: `1.25.0` → `1.26.0` (`go mod tidy` produced no further diffs)
- Dockerfile builder image: `golang:1.24-alpine` → `golang:1.26-alpine`
- CI `setup-go`: checkout first, then `go-version-file: go.mod` (replaces hardcoded `^1.21`)
- No golangci-lint pin in this repo, so nothing to bump there

## Test plan
- [x] `go mod tidy` with Go 1.26 toolchain
- [x] `go test ./...` and `make build` locally with Go 1.26
- [x] Confirm unit-test workflow installs Go from `go.mod` and passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fd0961d-39e0-464b-83b0-9eccefef56fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fd0961d-39e0-464b-83b0-9eccefef56fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

